### PR TITLE
feat: add mcgw

### DIFF
--- a/basic-vanilla-poc/bootstrap/applicationset/applicationset-bootstrap.yaml
+++ b/basic-vanilla-poc/bootstrap/applicationset/applicationset-bootstrap.yaml
@@ -32,6 +32,16 @@ spec:
         repoURL: https://github.com/rh-aiservices-bu/genai-rhoai-poc-template.git
         targetRevision: dev
         path: basic-vanilla-poc/bootstrap/anythingllm
+      - cluster: in-cluster
+        name: mcgw-install
+        repoURL: https://github.com/rh-aiservices-bu/genai-rhoai-poc-template.git
+        targetRevision: dev
+        path: common-utils/mcgw/install-operator
+      - cluster: in-cluster
+        name: mcgw-deploy
+        repoURL: https://github.com/rh-aiservices-bu/genai-rhoai-poc-template.git
+        targetRevision: dev
+        path: common-utils/mcgw/deploy
   template:
     metadata:
       name: "{{name}}"

--- a/common-utils/mcgw/deploy/enable-console-plugin.yaml
+++ b/common-utils/mcgw/deploy/enable-console-plugin.yaml
@@ -46,7 +46,7 @@ spec:
             - name: PLUGIN_NAME
               value: odf-console
           command:
-            - /bin/sh
+            - /bin/bash
             - -c
             - |
               echo "Attempting to enable ${PLUGIN_NAME} plugin"

--- a/common-utils/mcgw/deploy/enable-console-plugin.yaml
+++ b/common-utils/mcgw/deploy/enable-console-plugin.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: enable-odf-console-plugin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: enable-odf-console-plugin
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - consoles
+    verbs:
+      - get
+      - list
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: enable-odf-console-plugin
+subjects:
+- kind: ServiceAccount
+  name: enable-odf-console-plugin
+  namespace: openshift-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: enable-odf-console-plugin
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: enable-odf-console-plugin
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: enable-plugin
+          image: 'image-registry.openshift-image-registry.svc:5000/openshift/tools:latest'
+          command:
+            - /bin/sh
+            - -c
+            - |
+              PLUGIN_NAME=odf-console
+            
+              echo "Attempting to enable ${PLUGIN_NAME} plugin"
+              echo ""
+            
+              # Create the plugins section on the object if it doesn't exist
+              if [ -z "$(oc get consoles.operator.openshift.io cluster -o=jsonpath='{.spec.plugins}')" ]; then
+                echo "Creating plugins object"
+                oc patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": [] } }' --type=merge
+              fi
+            
+              INSTALLED_PLUGINS=$(oc get consoles.operator.openshift.io cluster -o=jsonpath='{.spec.plugins}')
+              echo "Current plugins:"
+              echo "${INSTALLED_PLUGINS}"
+            
+              if [[ "${INSTALLED_PLUGINS}" == *"${PLUGIN_NAME}"* ]]; then
+                  echo "${PLUGIN_NAME} is already enabled"
+              else
+                  echo "Enabling plugin: ${PLUGIN_NAME}"
+                  oc patch consoles.operator.openshift.io cluster --type=json --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "'"${PLUGIN_NAME}"'"}]'
+              fi
+            
+              sleep 6
+              oc get consoles.operator.openshift.io cluster -o=jsonpath='{.spec.plugins}'
+      serviceAccountName: enable-odf-console-plugin

--- a/common-utils/mcgw/deploy/enable-console-plugin.yaml
+++ b/common-utils/mcgw/deploy/enable-console-plugin.yaml
@@ -42,12 +42,13 @@ spec:
       containers:
         - name: enable-plugin
           image: 'image-registry.openshift-image-registry.svc:5000/openshift/tools:latest'
+          env:
+            - name: PLUGIN_NAME
+              value: odf-console
           command:
             - /bin/sh
             - -c
             - |
-              PLUGIN_NAME=odf-console
-            
               echo "Attempting to enable ${PLUGIN_NAME} plugin"
               echo ""
             

--- a/common-utils/mcgw/deploy/kustomization.yaml
+++ b/common-utils/mcgw/deploy/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+resources:
+  # prehook
+  - validate-install.yaml
+  # wave 0 deploy
+  - ocsinitialization.yaml
+  - enable-console-plugin.yaml
+  # wave 1 deploy
+  - storagecluster.yaml
+  - storagesystem.yaml
+
+patches:
+  - target:
+      group: batch
+      version: v1
+      kind: Job
+      name: validate-install
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env/1/value
+        value: odf-operator

--- a/common-utils/mcgw/deploy/ocsinitialization.yaml
+++ b/common-utils/mcgw/deploy/ocsinitialization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: ocs.openshift.io/v1
+kind: OCSInitialization
+metadata:
+  name: ocsinit
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  enableCephTools: false

--- a/common-utils/mcgw/deploy/storagecluster.yaml
+++ b/common-utils/mcgw/deploy/storagecluster.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: ocs-storagecluster
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  arbiter: {}
+  encryption:
+    keyRotation:
+      schedule: '@weekly'
+    kms: {}
+  externalStorage: {}
+  managedResources:
+    cephBlockPools: {}
+    cephCluster: {}
+    cephConfig: {}
+    cephDashboard: {}
+    cephFilesystems:
+      dataPoolSpec:
+        application: ""
+        erasureCoded:
+          codingChunks: 0
+          dataChunks: 0
+        mirroring: {}
+        quotas: {}
+        replicated:
+          size: 0
+        statusCheck:
+          mirror: {}
+    cephNonResilientPools:
+      count: 1
+      resources: {}
+      volumeClaimTemplate:
+        metadata: {}
+        spec:
+          resources: {}
+        status: {}
+    cephObjectStoreUsers: {}
+    cephObjectStores: {}
+    cephRBDMirror:
+      daemonCount: 1
+    cephToolbox: {}
+  mirroring: {}
+  multiCloudGateway:
+    dbStorageClassName: gp3-csi
+    reconcileStrategy: standalone
+  resourceProfile: balanced

--- a/common-utils/mcgw/deploy/storagesystem.yaml
+++ b/common-utils/mcgw/deploy/storagesystem.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: odf.openshift.io/v1alpha1
+kind: StorageSystem
+metadata:
+  name: ocs-storagecluster-storagesystem
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  kind: storagecluster.ocs.openshift.io/v1
+  name: ocs-storagecluster
+  namespace: openshift-storage

--- a/common-utils/mcgw/deploy/validate-install.yaml
+++ b/common-utils/mcgw/deploy/validate-install.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: validate-install
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: validate-install
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: validate-install
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+subjects:
+- kind: ServiceAccount
+  name: validate-install
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: validate-install
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: validate-install
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: phase-check
+          image: 'image-registry.openshift-image-registry.svc:5000/openshift/tools:latest'
+          env:
+            - name: POD_NAME_LABEL
+              value: app.kubernetes.io/name
+            - name: POD_NAME
+              value: replaceme
+          command:
+            - /bin/sh
+            - -c
+            - |
+              while true; do
+              echo "Checking Pod status.phase..."
+              POD_PHASE=$(oc get pod -l "$POD_NAME_LABEL"="$POD_NAME" -o jsonpath='{.items[0].status.phase}')
+              if [ "$POD_PHASE" = "Running" ]; then
+                echo "Pod is in Running phase."
+                exit 0
+              else
+                echo "Pod is in $POD_PHASE phase."
+              fi
+              sleep 5
+              done
+      serviceAccountName: validate-install

--- a/common-utils/mcgw/install-operator/kustomization.yaml
+++ b/common-utils/mcgw/install-operator/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+resources:
+  # wave 0 define namespace
+  - namespace.yaml
+  # wave 1 install operator
+  - operator-group.yaml
+  - subscription.yaml

--- a/common-utils/mcgw/install-operator/namespace.yaml
+++ b/common-utils/mcgw/install-operator/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "OpenShift Storage"
+    openshift.io/node-selector: ""
+    argocd.argoproj.io/sync-wave: "0"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-storage

--- a/common-utils/mcgw/install-operator/operator-group.yaml
+++ b/common-utils/mcgw/install-operator/operator-group.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: odf-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  targetNamespaces:
+    - openshift-storage

--- a/common-utils/mcgw/install-operator/subscription.yaml
+++ b/common-utils/mcgw/install-operator/subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: odf-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  channel: stable-4.17
+  installPlanApproval: Automatic
+  name: odf-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
I'm not wedded to this, but I have the code laying around. It lets us use ObjectBucketClaims which are easier to manage declaratively than using jobs and loops with MinIO, imo.

If we really want a UI that makes buckets browsable in the web UI, I suspect that adding something like [s3manager](https://github.com/cloudlena/s3manager) would be sufficient, especially if fronted with an OpenShift OAuth sidecar. It's not complicated, I've used it for a few projects, and it keeps the "unsupported" surface area to a minimum.

Open to discussion on the topic, and will own gutting and replacing with MinIO if that's consensus.

fixes: #2 