### PR TITLE
Fix: ODH TEC can read the MCGW Data Connection

### DIFF
--- a/common-utils/rhoai/config/workbench-imagestream-odh-tec.yaml
+++ b/common-utils/rhoai/config/workbench-imagestream-odh-tec.yaml
@@ -3,10 +3,10 @@ apiVersion: image.openshift.io/v1
 metadata:
   annotations:
     opendatahub.io/notebook-image-creator: admin
-    opendatahub.io/notebook-image-desc: 'quay.io/rh-aiservices-bu/odh-tec:1.2.0'
+    opendatahub.io/notebook-image-desc: 'quay.io/rh-aiservices-bu/odh-tec:1.2.1'
     opendatahub.io/notebook-image-name: 'CUSTOM: ODH-TEC'
     opendatahub.io/notebook-image-order: "04"
-    opendatahub.io/notebook-image-url: 'quay.io/rh-aiservices-bu/odh-tec:1.2.0'
+    opendatahub.io/notebook-image-url: 'quay.io/rh-aiservices-bu/odh-tec:1.2.1'
     opendatahub.io/recommended-accelerators: "[]"
     argocd.argoproj.io/sync-wave: "1"
   name: is-odh-tec
@@ -19,15 +19,15 @@ spec:
   lookupPolicy:
     local: true
   tags:
-    - name: "1.2.0"
+    - name: "1.2.1"
       annotations:
         opendatahub.io/notebook-python-dependencies: '[]'
         opendatahub.io/notebook-software: '[]'
-        openshift.io/imported-from: 'quay.io/rh-aiservices-bu/odh-tec:1.2.0'
+        openshift.io/imported-from: 'quay.io/rh-aiservices-bu/odh-tec:1.2.1'
       from:
         kind: DockerImage
         name: >-
-          quay.io/rh-aiservices-bu/odh-tec:1.2.0
+          quay.io/rh-aiservices-bu/odh-tec:1.2.1
       importPolicy:
         importMode: Legacy
       referencePolicy:


### PR DESCRIPTION
Update to ODH-TEC 1.2.1 to pick up change that allows working with Data Connections that specify bucket, without RBAC to list the bucket associated with the access key. This is the default permissions set when using ObjectBucketClaims with MCGW.