### PR TITLE
Fix for when the model route gets broken due to model server changes live

### DIFF
--- a/basic-vanilla-poc/bootstrap/anythingllm/deploy-anythingllm.yaml
+++ b/basic-vanilla-poc/bootstrap/anythingllm/deploy-anythingllm.yaml
@@ -113,7 +113,7 @@ spec:
 
           echo -n 'Waiting for public model route'
           while true; do
-              route="$(oc get route -n istio-system aligned-granite-${USER_PROJECT} -ojsonpath='{.status.ingress[0].host}' 2>/dev/null ||:)"
+              route="$(oc get route -n istio-system -l serving.knative.dev/route=aligned-granite-predictor -ojsonpath='{items[0].status.ingress[0].host}' 2>/dev/null ||:)"
               echo -n .
               if [ -n "$route" ]; then
                   break

--- a/basic-vanilla-poc/bootstrap/applicationset/applicationset-bootstrap.yaml
+++ b/basic-vanilla-poc/bootstrap/applicationset/applicationset-bootstrap.yaml
@@ -74,7 +74,7 @@ spec:
         server: "https://kubernetes.default.svc"
       syncPolicy:
         automated:
-          prune: true
+          prune: false
           selfHeal: true
         syncOptions:
           - RespectIgnoreDifferences=true


### PR DESCRIPTION
- Removes prune (temporarily)
  - see also: https://github.com/argoproj/argo-cd/discussions/16448
- Enable better route detection if it gets recreated out of band