### PR TITLE
fix: dynamically detect download architecture at build time

### DIFF
--- a/hack/s3-upload/Containerfile
+++ b/hack/s3-upload/Containerfile
@@ -7,7 +7,8 @@ RUN mkdir -p /s3cmd && \
     dnf -y clean all && \
     python3 -m pip install --no-cache-dir s3cmd
 
-RUN curl -sLo- "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz" | tar xvz -C /usr/local/bin && \
+RUN arch=$(uname -m); if [ "$arch" = "x86_64" ]; then dlarch=amd64; elif [ "$arch" = "aarch64" ]; then dlarch=arm64; else echo "Unrecognized arch: $arch" >&2; exit 1; fi; \
+    curl -sLo- "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux-$dlarch.tar.gz" | tar xvz -C /usr/local/bin && \
     chmod +x /usr/local/bin/{kubectl,oc}
 
 COPY overlay/ /


### PR DESCRIPTION
This resolves issues with using s3-upload from aarch64 systems, including M-series Macs.