### PR TITLE
Enable tweaking individual applications' syncPolicy

### DIFF
--- a/basic-vanilla-poc/bootstrap/applicationset/applicationset-bootstrap.yaml
+++ b/basic-vanilla-poc/bootstrap/applicationset/applicationset-bootstrap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bootstrap
   namespace: openshift-gitops
 spec:
+  goTemplate: true
   generators:
   - list:
       elements:
@@ -47,6 +48,7 @@ spec:
         repoURL: https://github.com/rh-aiservices-bu/genai-rhoai-poc-template.git
         targetRevision: dev
         path: basic-vanilla-poc/bootstrap/model-deploy
+        prune: "false"
       - cluster: in-cluster
         name: poc-primer
         repoURL: https://github.com/rh-aiservices-bu/genai-rhoai-poc-template.git
@@ -59,23 +61,19 @@ spec:
         path: basic-vanilla-poc/bootstrap/anythingllm
   template:
     metadata:
-      name: "{{name}}"
+      name: "{{ .name }}"
       namespace: openshift-gitops
       labels:
         component: bootstrap
-        purpose: "{{name}}"
     spec:
       project: default
       source:
-        repoURL: "{{repoURL}}"
-        targetRevision: "{{targetRevision}}"
-        path: "{{path}}"
+        repoURL: "{{ .repoURL }}"
+        targetRevision: "{{ .targetRevision }}"
+        path: "{{ .path }}"
       destination:
-        server: "https://kubernetes.default.svc"
+        name: "{{ .cluster }}"
       syncPolicy:
-        automated:
-          prune: false
-          selfHeal: true
         syncOptions:
           - RespectIgnoreDifferences=true
           - Retry=true
@@ -84,4 +82,10 @@ spec:
           backoff:
             duration: 15s
             factor: 2
-            maxDuration: 5m # Maximum retry interval
+            maxDuration: 5m
+  templatePatch: |
+    spec:
+      syncPolicy:
+        automated:
+          prune: {{ .prune | default "true" }}
+          selfHeal: {{ .selfHeal | default "true" }}


### PR DESCRIPTION
This change will allow us to enable prune and selfHeal by default, but allow us to tweak individual applications to work around issues (such as the Route in the Model Deployment) or to iteratively test and debug during development.