### PR TITLE
Enable some upload consistency

### DIFF
--- a/hack/s3-upload/Containerfile
+++ b/hack/s3-upload/Containerfile
@@ -7,8 +7,6 @@ RUN mkdir -p /s3cmd && \
     dnf -y clean all && \
     python3 -m pip install --no-cache-dir s3cmd
 
-ARG IBMCLOUD_VERSION=2.32.0
-
 RUN set -o pipefail && \
     arch=$(uname -m) && \
     if [ "$arch" = "x86_64" ]; then \

--- a/hack/s3-upload/Containerfile
+++ b/hack/s3-upload/Containerfile
@@ -7,7 +7,18 @@ RUN mkdir -p /s3cmd && \
     dnf -y clean all && \
     python3 -m pip install --no-cache-dir s3cmd
 
-RUN arch=$(uname -m); if [ "$arch" = "x86_64" ]; then dlarch=amd64-rhel9; elif [ "$arch" = "aarch64" ]; then dlarch=arm64; else echo "Unrecognized arch: $arch" >&2; exit 1; fi; \
+ARG IBMCLOUD_VERSION=2.32.0
+
+RUN set -o pipefail && \
+    arch=$(uname -m) && \
+    if [ "$arch" = "x86_64" ]; then \
+        dlarch=amd64-rhel9; \
+    elif [ "$arch" = "aarch64" ]; then \
+        dlarch=arm64; \
+    else \
+        echo "Unrecognized arch: $arch" >&2; \
+        exit 1; \
+    fi; \
     url="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux-$dlarch.tar.gz" && \
     echo "Downloading: $url" && \
     curl -sLo- "$url" | tar xvz -C /usr/local/bin && \

--- a/hack/s3-upload/overlay/usr/local/bin/s3-upload.sh
+++ b/hack/s3-upload/overlay/usr/local/bin/s3-upload.sh
@@ -17,10 +17,10 @@ function show_usage {
 while (("${#}" > 0)); do
     case "$1" in
     *)
-        if [ -e "$1" ]; then
+        if [ -d "$1" ]; then
             paths_to_upload+=("$1")
         else
-            echo "Unrecognized path provided: $1" >&2
+            echo "Non-directory path provided: $1" >&2
             show_usage
             exit 1
         fi
@@ -90,7 +90,7 @@ dest="s3://${AWS_S3_BUCKET}/models/"
 
 # Upload directories recursively, using
 for input in "${paths_to_upload[@]}"; do
-    s3cmd put --recursive "$input" "$dest"
+    s3cmd sync --no-delete-removed "$input" "$dest"
 done
 
 s3cmd ls "$dest"

--- a/hack/s3-upload/overlay/usr/local/bin/s3-upload.sh
+++ b/hack/s3-upload/overlay/usr/local/bin/s3-upload.sh
@@ -8,8 +8,29 @@ if ! oc whoami >/dev/null 2>&1; then
     exit 1
 fi
 
-if (("${#}" < 1)); then
+paths_to_upload=()
+
+function show_usage {
     echo "usage: upload.sh PATH [PATH [...]]" >&2
+}
+
+while (("${#}" > 0)); do
+    case "$1" in
+    *)
+        if [ -e "$1" ]; then
+            paths_to_upload+=("$1")
+        else
+            echo "Unrecognized path provided: $1" >&2
+            show_usage
+            exit 1
+        fi
+        ;;
+    esac
+    shift
+done
+
+if ((${#paths_to_upload} < 1)); then
+    show_usage
     exit 0
 fi
 
@@ -45,7 +66,7 @@ else
     use_https=True
 fi
 
-cat <<EOF >/tmp/s3cfg
+cat <<EOF >/s3cmd/.s3cfg
 [default]
 check_ssl_certificate = True
 check_ssl_hostname = True
@@ -62,15 +83,14 @@ EOF
 
 function s3cmd {
     set -x
-    /usr/local/bin/s3cmd -c /tmp/s3cfg "${@}"
+    /usr/local/bin/s3cmd "${@}"
     { set +x; } 2>/dev/null
 }
 dest="s3://${AWS_S3_BUCKET}/models/"
 
 # Upload directories recursively, using
-for input in "${@}"; do
+for input in "${paths_to_upload[@]}"; do
     s3cmd put --recursive "$input" "$dest"
 done
 
-set -x
 s3cmd ls "$dest"


### PR DESCRIPTION
Some folks using the script are having issues with connection dropouts, timeouts, resets, etc. This change gives some more helpful output in the script and, importantly, allows it to recover from where it left off on a previous upload attempt. Running the script multiple times in a row should eventually result in a successful upload now.