### PR TITLE
fix: revert to old route selector now that we have no prune

### DIFF
--- a/basic-vanilla-poc/bootstrap/anythingllm/deploy-anythingllm.yaml
+++ b/basic-vanilla-poc/bootstrap/anythingllm/deploy-anythingllm.yaml
@@ -113,7 +113,7 @@ spec:
 
           echo -n 'Waiting for public model route'
           while true; do
-              route="$(oc get route -n istio-system -l serving.knative.dev/route=aligned-granite-predictor -ojsonpath='{items[0].status.ingress[0].host}' 2>/dev/null ||:)"
+              route="$(oc get route -n istio-system aligned-granite-${USER_PROJECT} -ojsonpath='{.status.ingress[0].host}' 2>/dev/null ||:)"
               echo -n .
               if [ -n "$route" ]; then
                   break


### PR DESCRIPTION
The issues with the predictor route was fixed by removing the prune on the model-deploy app. Now the route that's created is less resilient and causing some issues with templating AnythingLLM correctly, so revert to the old behavior here.