### PR TITLE
feat: update s3-sync to skip sync when model sums and size match

### DIFF
--- a/basic-vanilla-poc/bootstrap/model-deploy/synchronize-model.yaml
+++ b/basic-vanilla-poc/bootstrap/model-deploy/synchronize-model.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: s3-sync
-          image: quay.io/jharmison/s3-sync:0.3.1
+          image: quay.io/jharmison/s3-sync:0.4.0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash


### PR DESCRIPTION
This PR picks up [these changes](https://github.com/jharmison-redhat/s3-sync/compare/0.3.1...0.4.0) in s3-sync which enable validating checksums and file size in concert to determine whether to skip a given sync. Certain operations could result in the sync job being recreated, and this simplifies the process radically if that happens.