### PR TITLE
Fix up a few small details

### DIFF
--- a/basic-vanilla-poc/bootstrap/model-deploy/deploy-model.yaml
+++ b/basic-vanilla-poc/bootstrap/model-deploy/deploy-model.yaml
@@ -110,11 +110,11 @@ spec:
       name: ""
       resources:
         limits:
-          cpu: "4"
-          memory: 12Gi
+          cpu: "8"
+          memory: 10Gi
           nvidia.com/gpu: "1"
         requests:
-          cpu: "2"
+          cpu: "4"
           memory: 8Gi
           nvidia.com/gpu: "1"
       runtime: aligned-granite

--- a/common-utils/rhoai/config/dashboardconfig.yaml
+++ b/common-utils/rhoai/config/dashboardconfig.yaml
@@ -7,14 +7,30 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
 spec:
   modelServerSizes:
-    - name: Standard
+    - name: Small
       resources:
         limits:
-          cpu: "12"
-          memory: 24Gi
+          cpu: "2"
+          memory: 8Gi
         requests:
+          cpu: "1"
+          memory: 4Gi
+    - name: Medium
+      resources:
+        limits:
           cpu: "8"
-          memory: 14Gi
+          memory: 10Gi
+        requests:
+          cpu: "4"
+          memory: 8Gi
+    - name: Large
+      resources:
+        limits:
+          cpu: "10"
+          memory: 20Gi
+        requests:
+          cpu: "6"
+          memory: 16Gi
   notebookController:
     enabled: true
     notebookNamespace: rhods-notebooks

--- a/common-utils/rhoai/config/dashboardconfig.yaml
+++ b/common-utils/rhoai/config/dashboardconfig.yaml
@@ -36,20 +36,43 @@ spec:
     notebookNamespace: rhods-notebooks
     pvcSize: 50Gi
   notebookSizes:
-    - name: Standard
-      resources:
-        limits:
-          cpu: "12"
-          memory: 24Gi
-        requests:
-          cpu: "8"
-          memory: 24Gi
     - name: Small
       resources:
         limits:
-          cpu: "4"
+          cpu: "2"
           memory: 8Gi
         requests:
-          cpu: "2"
-          memory: 4Gi
-  templateOrder: []
+          cpu: "1"
+          memory: 8Gi
+    - name: Standard
+      resources:
+        limits:
+          cpu: '4'
+          memory: 16Gi
+        requests:
+          cpu: '2'
+          memory: 10Gi
+    - name: Medium
+      resources:
+        limits:
+          cpu: "6"
+          memory: 24Gi
+        requests:
+          cpu: "3"
+          memory: 24Gi
+    - name: Large
+      resources:
+        limits:
+          cpu: "14"
+          memory: 56Gi
+        requests:
+          cpu: "7"
+          memory: 56Gi
+    - name: X Large
+      resources:
+        limits:
+          cpu: "30"
+          memory: 120Gi
+        requests:
+          cpu: "15"
+          memory: 120Gi

--- a/common-utils/rhoai/config/dashboardconfig.yaml
+++ b/common-utils/rhoai/config/dashboardconfig.yaml
@@ -34,7 +34,7 @@ spec:
   notebookController:
     enabled: true
     notebookNamespace: rhods-notebooks
-    pvcSize: 50Gi
+    pvcSize: 20Gi
   notebookSizes:
     - name: Small
       resources:

--- a/common-utils/rhoai/deploy/dsc.yaml
+++ b/common-utils/rhoai/deploy/dsc.yaml
@@ -7,10 +7,6 @@ metadata:
 spec:
   components:
     codeflare:
-      managementState: Removed
-    dashboard:
-      managementState: Managed
-    datasciencepipelines:
       managementState: Managed
     kserve:
       managementState: Managed
@@ -20,15 +16,22 @@ spec:
             type: OpenshiftDefaultIngress
         managementState: Managed
         name: knative-serving
-    kueue:
-      managementState: Removed
-    modelmeshserving:
-      managementState: Removed
-    ray:
-      managementState: Removed
-    trainingoperator:
+    modelregistry:
+      registriesNamespace: rhoai-model-registries
       managementState: Removed
     trustyai:
-      managementState: Removed
+      managementState: Managed
+    ray:
+      managementState: Managed
+    kueue:
+      managementState: Managed
     workbenches:
+      managementState: Managed
+    dashboard:
+      managementState: Managed
+    modelmeshserving:
+      managementState: Removed
+    datasciencepipelines:
+      managementState: Managed
+    trainingoperator:
       managementState: Managed


### PR DESCRIPTION
This PR:
- Enables more components in the DSC, specifically the TrustyAI and Distributed Workloads components, so those could be showed off if desired. Also reorganizes the DSC to align with the current default for 2.16.1 (fixes: #21 )
- Normalizes the Model Server sizes to match the product defaults, and brings our existing vLLM deployment in line with the default Medium size (which it was closest to).
- Normalizes the Workbench sizes to match the product defaults, but adds a specific custom one to align with the AnythingLLM deployment, which had requirements that were sufficiently different from the default size to not rock the boat there too hard (fixes: #24 )
- Returns PVC size defaults to 20Gi, instead of 50Gi. This only affects UX when creating custom workbenches, and 20Gi default is more than plenty.

All told, a bunch of small tweaks. I'll give them some more thorough testing of the automation once we get the other PRs merged, but I don't suspect any major problems - I've tested all of this manually.